### PR TITLE
Move to Quart and quart-discord; uses async

### DIFF
--- a/Part 1/main.py
+++ b/Part 1/main.py
@@ -1,26 +1,43 @@
 from quart import Quart, render_template, request, session
-from .oauth import Oauth
-
+from quart_discord import DiscordOAuth2Session
 
 app = Quart(__name__)
 app.config["SECRET_KEY"] = "test123"
+app.config["DISCORD_CLIENT_ID"] = 1234567890    # Discord client ID.
+app.config["DISCORD_CLIENT_SECRET"] = "SHHHH"                # Discord client secret.
+app.config["DISCORD_REDIRECT_URI"] = ""                 # URL to your callback endpoint.
+
+discord = DiscordOAuth2Session(app)
 
 @app.route("/")
 async def home():
-	return await render_template("index.html",discord_url= Oauth.discord_login_url)
+	return await render_template("index.html",discord_url="login url here")
 
 @app.route("/login")
 async def login():
-	code = request.args.get("code")
+	"""The function that logs the user in.
 
-	at = Oauth.get_access_token(code)
-	session["token"] = at
+	It will redirect them to your Discord OAuth2 Flow,
+	and they will then be redirected back to your callback
+	endpoint, or REDIRECT_URI.
+	"""	
+	return await discord.create_session()
 
-	user = Oauth.get_user_json(at)
-	user_name, user_id = user.get("username"), user.get("discriminator")
+@app.route("/callback")
+async def callback():
+	"""Callback.
 
-	return f"Success, logged in as {user_name}#{user_id}"
+	This will handle the authentication of
+	the user, and create the session and cookies.
+	"""
+	await discord.callback()
+	user = await discord.fetch_user()
+	return f"Hello, {user.name}#{user.discriminator}! <img src='{user.avatar_url}'>"
 
+@app.route('/logout')
+async def logout():
+	"""Logs out the user by REVOKING!!! their token."""
+	discord.revoke()
 
 if __name__ == "__main__":
 	app.run(debug=True)

--- a/Part 1/main.py
+++ b/Part 1/main.py
@@ -1,16 +1,16 @@
-from flask import Flask, render_template, request, session
-from oauth import Oauth
+from quart import Quart, render_template, request, session
+from .oauth import Oauth
 
 
-app = Flask(__name__)
+app = Quart(__name__)
 app.config["SECRET_KEY"] = "test123"
 
 @app.route("/")
-def home():
-	return render_template("index.html",discord_url= Oauth.discord_login_url)
+async def home():
+	return await render_template("index.html",discord_url= Oauth.discord_login_url)
 
 @app.route("/login")
-def login():
+async def login():
 	code = request.args.get("code")
 
 	at = Oauth.get_access_token(code)


### PR DESCRIPTION
I also moved over to the Quart framework and [quart-discord](https://quart-discord.readthedocs.io/en/latest/api.html), which makes it a lot easier to create and use Discord OAuth2 Flows. I also added comments and formatted the code in a better way.

<details>
<summary>What's next on this fork</summary>
<br>
Next I'll bring in discord-ext-ipc to better interface with the bot. This will allow us to use our bot almost as a REST API, and therefore allow the webserver to work with better integration with the bot.
</details>
